### PR TITLE
Fix/remove unnecessary default deprecated

### DIFF
--- a/src/main/scala/com/github/swagger/enumeratum/converter/SwaggerEnumeratumModelConverter.scala
+++ b/src/main/scala/com/github/swagger/enumeratum/converter/SwaggerEnumeratumModelConverter.scala
@@ -28,14 +28,14 @@ class SwaggerEnumeratumModelConverter extends ModelResolver(Json.mapper()) {
       nullSafeList(annotatedType.getCtxAnnotations).foreach {
         case p: Parameter => {
           noneIfEmpty(p.description).foreach(desc => sp.setDescription(desc))
-          sp.setDeprecated(p.deprecated)
+          if (p.deprecated) { sp.setDeprecated(true)}
           noneIfEmpty(p.example).foreach(ex => sp.setExample(ex))
           noneIfEmpty(p.name).foreach(name => sp.setName(name))
         }
         case s: SchemaAnnotation => {
           noneIfEmpty(s.description).foreach(desc => sp.setDescription(desc))
           noneIfEmpty(s.defaultValue).foreach(df => sp.setDefault(df))
-          sp.setDeprecated(s.deprecated)
+          if (s.deprecated) { sp.setDeprecated(true)}
           noneIfEmpty(s.example).foreach(ex => sp.setExample(ex))
           noneIfEmpty(s.name).foreach(name => sp.setName(name))
           Option(s.accessMode).foreach {

--- a/src/test/scala/com/github/swagger/enumeratum/converter/ModelPropertyParserTest.scala
+++ b/src/test/scala/com/github/swagger/enumeratum/converter/ModelPropertyParserTest.scala
@@ -87,6 +87,7 @@ class ModelPropertyParserTest extends AnyFlatSpec with Matchers with OptionValue
     schema.getDescription shouldEqual "An annotated field"
     schema.getName shouldEqual "field"
     schema.getDefault should be (null)
+    schema.getDeprecated should be (null)
     schema.getEnum.asScala shouldEqual Ctx.Color.values.map(_.entryName)
     nullSafeList(model.value.getRequired) shouldBe Seq("field")
   }


### PR DESCRIPTION
Avoid `"deprecated":false` unless explicitly set to `true`
Before:
```json
{
  "name":"resolution",
  "in":"query",
  "schema":{
    "deprecated":false,
    "enum":["Days","Hours"],
    "type":"string"
  }
}
```   
After:
```json
{
  "name":"resolution",
  "in":"query",
  "schema":{
    "enum":["Days","Hours"],
    "type":"string"
  }
}
```     